### PR TITLE
feat: Add serialized_column macro for JSON/JSONB/YAML column support

### DIFF
--- a/docs/serialized_columns.md
+++ b/docs/serialized_columns.md
@@ -1,0 +1,221 @@
+# Serialized Columns
+
+Grant provides a powerful `serialized_column` macro for storing structured data in JSON, JSONB, or YAML database columns with full type safety and dirty tracking support.
+
+## Overview
+
+The `serialized_column` macro allows you to:
+- Store complex Crystal objects in database columns
+- Maintain type safety with automatic serialization/deserialization
+- Track changes in nested objects (dirty tracking)
+- Support JSON, JSONB, and YAML formats
+- Work seamlessly with different database adapters
+
+## Basic Usage
+
+```crystal
+# Define a settings class
+class UserSettings
+  include JSON::Serializable
+  include Granite::SerializedObject  # For dirty tracking
+  
+  property theme : String = "light"
+  property notifications_enabled : Bool = true
+  property items_per_page : Int32 = 20
+end
+
+# Use in your model
+class User < Granite::Base
+  column id : Int64, primary: true
+  column name : String
+  
+  # Define a serialized column
+  serialized_column :settings, UserSettings, format: :json
+end
+
+# Usage
+user = User.new(name: "John")
+user.settings = UserSettings.new(theme: "dark", notifications_enabled: false)
+user.save
+
+# Access the settings object
+user.settings.theme # => "dark"
+user.settings.notifications_enabled # => false
+
+# Modify settings
+user.settings.items_per_page = 50
+user.settings_changed? # => true
+user.save
+```
+
+## Serialization Formats
+
+### JSON (MySQL, PostgreSQL)
+```crystal
+serialized_column :settings, UserSettings, format: :json
+```
+
+### JSONB (PostgreSQL binary JSON)
+```crystal
+serialized_column :preferences, UserPreferences, format: :jsonb
+```
+
+### YAML
+```crystal
+serialized_column :config, AppConfig, format: :yaml
+```
+
+## Dirty Tracking
+
+Serialized columns fully integrate with Grant's dirty tracking system:
+
+```crystal
+# Check if the serialized column has changed
+user.settings_changed? # => false
+
+# Modify nested object
+user.settings.theme = "dark"
+user.settings_changed? # => true
+user.settings.changed? # => true (on the nested object)
+
+# See what changed
+user.settings.changes # => {"theme" => {"light", "dark"}}
+
+# Save clears dirty state
+user.save
+user.settings_changed? # => false
+user.settings.changed? # => false
+```
+
+## Advanced Example
+
+```crystal
+# Complex nested structure
+class NotificationSettings
+  include JSON::Serializable
+  include Granite::SerializedObject
+  
+  property email : Bool = true
+  property push : Bool = true
+  property sms : Bool = false
+  property frequency : String = "immediate"
+end
+
+class UserPreferences
+  include JSON::Serializable
+  include Granite::SerializedObject
+  
+  property language : String = "en"
+  property timezone : String = "UTC"
+  property notifications : NotificationSettings = NotificationSettings.new
+  property beta_features : Array(String) = [] of String
+end
+
+class User < Granite::Base
+  serialized_column :preferences, UserPreferences, format: :jsonb
+end
+
+# Usage
+user = User.new
+user.preferences = UserPreferences.new
+user.preferences.language = "es"
+user.preferences.notifications.email = false
+user.preferences.beta_features = ["new_ui", "advanced_search"]
+user.save
+```
+
+## Database Column Types
+
+The serialized data is stored as strings in the database. Make sure your columns are the appropriate type:
+
+### PostgreSQL
+```sql
+CREATE TABLE users (
+  settings JSON,      -- For format: :json
+  preferences JSONB,  -- For format: :jsonb
+  config TEXT        -- For format: :yaml
+);
+```
+
+### MySQL
+```sql
+CREATE TABLE users (
+  settings JSON,     -- For format: :json (MySQL 5.7+)
+  preferences JSON,  -- JSONB treated as JSON in MySQL
+  config TEXT       -- For format: :yaml
+);
+```
+
+### SQLite
+```sql
+CREATE TABLE users (
+  settings TEXT,     -- All formats stored as TEXT
+  preferences TEXT,
+  config TEXT
+);
+```
+
+## Requirements for Serializable Classes
+
+Your serializable classes must:
+
+1. Include the appropriate serialization module:
+   - `JSON::Serializable` for JSON/JSONB columns
+   - `YAML::Serializable` for YAML columns
+
+2. Include `Granite::SerializedObject` for dirty tracking support
+
+3. Have a default constructor or provide default values for all properties
+
+## Performance Considerations
+
+- Objects are deserialized lazily on first access
+- Deserialized objects are cached until the column value changes
+- Changes to nested objects are tracked efficiently
+- Serialization happens automatically before save
+
+## Best Practices
+
+1. **Keep serialized objects focused** - Don't store entire application state
+2. **Use appropriate formats**:
+   - JSON/JSONB for API data, settings, configurations
+   - YAML for human-readable configurations
+3. **Include defaults** - Always provide sensible defaults for properties
+4. **Version your schemas** - Consider adding version fields for migration support
+5. **Index JSONB columns** - PostgreSQL supports indexes on JSONB fields
+
+## Limitations
+
+- Serialized columns cannot be queried directly in database queries
+- Changes to the serializable class structure require data migration
+- Large objects can impact performance
+- Not suitable for data that needs to be indexed or joined
+
+## Example: User Settings with Versioning
+
+```crystal
+class UserSettingsV2
+  include JSON::Serializable
+  include Granite::SerializedObject
+  
+  property version : Int32 = 2
+  property theme : String = "light"
+  property notifications_enabled : Bool = true
+  property items_per_page : Int32 = 20
+  property new_feature : String = "default"
+  
+  # Migration logic
+  def self.from_json(json : String)
+    data = JSON.parse(json)
+    version = data["version"]?.try(&.as_i) || 1
+    
+    if version < 2
+      # Migrate v1 to v2
+      data["new_feature"] = "default"
+      data["version"] = 2
+    end
+    
+    new(data.to_json)
+  end
+end
+```

--- a/spec/granite/serialized_column_spec.cr
+++ b/spec/granite/serialized_column_spec.cr
@@ -1,0 +1,271 @@
+require "../spec_helper"
+require "json"
+require "yaml"
+
+# Test classes for serialization
+class UserSettings
+  include JSON::Serializable
+  include YAML::Serializable
+  include Granite::SerializedObject
+  
+  getter theme : String = "light"
+  getter notifications_enabled : Bool = true
+  getter items_per_page : Int32 = 20
+  
+  track_changes_for theme, notifications_enabled, items_per_page
+  
+  def initialize(@theme = "light", @notifications_enabled = true, @items_per_page = 20)
+    @_changed = false
+    @_original_values = {} of String => Tuple(String, String)
+  end
+end
+
+class UserPreferences
+  include JSON::Serializable
+  include YAML::Serializable
+  include Granite::SerializedObject
+  
+  property language : String = "en"
+  property timezone : String = "UTC"
+  property beta_features : Array(String) = [] of String
+  
+  track_changes_for language, timezone
+  
+  def initialize(@language = "en", @timezone = "UTC", @beta_features = [] of String)
+    @_changed = false
+    @_original_values = {} of String => Tuple(String, String)
+  end
+end
+
+class AppConfig
+  include JSON::Serializable
+  include YAML::Serializable
+  include Granite::SerializedObject
+  
+  property debug_mode : Bool = false
+  property log_level : String = "info"
+  property api_endpoints : Hash(String, String) = {} of String => String
+  
+  track_changes_for log_level
+  
+  def initialize(@debug_mode = false, @log_level = "info", @api_endpoints = {} of String => String)
+    @_changed = false
+    @_original_values = {} of String => Tuple(String, String)
+  end
+  
+  # Manual tracking for complex types
+  def debug_mode=(value : Bool)
+    if @debug_mode != value
+      _track_change("debug_mode", @debug_mode.to_s, value.to_s)
+    end
+    @debug_mode = value
+  end
+end
+
+{% begin %}
+  {% adapter_literal = env("CURRENT_ADAPTER").id %}
+
+  class SerializedUser < Granite::Base
+    connection {{ adapter_literal }}
+    table serialized_users
+    
+    column id : Int64, primary: true
+    column name : String?
+    
+    serialized_column :settings, UserSettings, format: :json
+    serialized_column :preferences, UserPreferences, format: :jsonb
+    serialized_column :config, AppConfig, format: :yaml
+    
+    timestamps
+  end
+{% end %}
+
+# Setup table
+SerializedUser.exec("DROP TABLE IF EXISTS serialized_users")
+
+case CURRENT_ADAPTER
+when "sqlite"
+  SerializedUser.exec(<<-SQL)
+    CREATE TABLE serialized_users (
+      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      name TEXT,
+      _serialized_settings TEXT,
+      _serialized_preferences TEXT,
+      _serialized_config TEXT,
+      created_at TEXT,
+      updated_at TEXT
+    )
+  SQL
+when "pg"
+  SerializedUser.exec(<<-SQL)
+    CREATE TABLE serialized_users (
+      id BIGSERIAL PRIMARY KEY,
+      name VARCHAR,
+      _serialized_settings JSON,
+      _serialized_preferences JSONB,
+      _serialized_config TEXT,
+      created_at TIMESTAMP,
+      updated_at TIMESTAMP
+    )
+  SQL
+when "mysql"
+  SerializedUser.exec(<<-SQL)
+    CREATE TABLE serialized_users (
+      id BIGINT PRIMARY KEY AUTO_INCREMENT,
+      name VARCHAR(255),
+      _serialized_settings JSON,
+      _serialized_preferences JSON,
+      _serialized_config TEXT,
+      created_at TIMESTAMP,
+      updated_at TIMESTAMP
+    )
+  SQL
+end
+
+describe Granite::SerializedColumn do
+  describe "JSON serialization" do
+    it "serializes and deserializes objects" do
+      user = SerializedUser.new(name: "John")
+      settings = UserSettings.new(theme: "dark", notifications_enabled: false, items_per_page: 50)
+      
+      user.settings = settings
+      user.save
+      
+      # Reload to test deserialization
+      reloaded = SerializedUser.find!(user.id)
+      reloaded.settings.should_not be_nil
+      reloaded.settings.not_nil!.theme.should eq("dark")
+      reloaded.settings.not_nil!.notifications_enabled.should eq(false)
+      reloaded.settings.not_nil!.items_per_page.should eq(50)
+    end
+    
+    it "handles nil values" do
+      user = SerializedUser.new(name: "Jane")
+      user.settings.should be_nil
+      user.save
+      
+      reloaded = SerializedUser.find!(user.id)
+      reloaded.settings.should be_nil
+    end
+  end
+  
+  describe "JSONB serialization" do
+    it "works the same as JSON" do
+      user = SerializedUser.new(name: "Bob")
+      prefs = UserPreferences.new(
+        language: "es",
+        timezone: "America/New_York",
+        beta_features: ["new_ui", "dark_mode"]
+      )
+      
+      user.preferences = prefs
+      user.save
+      
+      reloaded = SerializedUser.find!(user.id)
+      reloaded.preferences.should_not be_nil
+      reloaded.preferences.not_nil!.language.should eq("es")
+      reloaded.preferences.not_nil!.timezone.should eq("America/New_York")
+      reloaded.preferences.not_nil!.beta_features.should eq(["new_ui", "dark_mode"])
+    end
+  end
+  
+  describe "YAML serialization" do
+    it "serializes complex objects" do
+      user = SerializedUser.new(name: "Alice")
+      config = AppConfig.new(
+        debug_mode: true,
+        log_level: "debug",
+        api_endpoints: {
+          "users" => "https://api.example.com/users",
+          "posts" => "https://api.example.com/posts"
+        }
+      )
+      
+      user.config = config
+      user.save
+      
+      reloaded = SerializedUser.find!(user.id)
+      reloaded.config.should_not be_nil
+      reloaded.config.not_nil!.debug_mode.should eq(true)
+      reloaded.config.not_nil!.log_level.should eq("debug")
+      reloaded.config.not_nil!.api_endpoints["users"].should eq("https://api.example.com/users")
+    end
+  end
+  
+  describe "dirty tracking" do
+    it "tracks changes in nested objects" do
+      user = SerializedUser.create(name: "Dave")
+      settings = UserSettings.new
+      user.settings = settings
+      user.save
+      
+      # Modify nested object
+      user.settings.not_nil!.theme = "dark"
+      user.settings_changed?.should be_true
+      user.settings.not_nil!.changed?.should be_true
+      
+      user.save
+      
+      # After save, changes should be reset
+      user.settings_changed?.should be_false
+      user.settings.not_nil!.changed?.should be_false
+    end
+    
+    it "tracks multiple changes" do
+      settings = UserSettings.new
+      settings.theme = "dark"
+      settings.notifications_enabled = false
+      
+      changes = settings.changes
+      changes.size.should eq(2)
+      changes["theme"].should eq({"light", "dark"})
+      changes["notifications_enabled"].should eq({"true", "false"})
+    end
+    
+    it "propagates changes to parent model" do
+      user = SerializedUser.new(name: "Eve")
+      settings = UserSettings.new
+      user.settings = settings
+      user.save
+      
+      # Clear any dirty state
+      user.settings_changed?.should be_false
+      
+      # Change nested object
+      user.settings.not_nil!.items_per_page = 100
+      user.settings_changed?.should be_true
+    end
+  end
+  
+  describe "caching behavior" do
+    it "caches deserialized objects" do
+      user = SerializedUser.create(name: "Frank")
+      user.settings = UserSettings.new(theme: "dark")
+      user.save
+      
+      # First access deserializes
+      settings1 = user.settings
+      # Second access should return same object
+      settings2 = user.settings
+      
+      settings1.should be(settings2) # Same object reference
+    end
+    
+    it "clears cache when setting raw value" do
+      user = SerializedUser.create(name: "Grace")
+      user.settings = UserSettings.new(theme: "dark")
+      user.save
+      
+      # Get cached object
+      settings1 = user.settings
+      
+      # Set raw JSON
+      user.settings = %({"theme":"light","notifications_enabled":true,"items_per_page":20})
+      
+      # Should return new object
+      settings2 = user.settings
+      settings1.should_not be(settings2)
+      settings2.not_nil!.theme.should eq("light")
+    end
+  end
+end

--- a/src/granite/base.cr
+++ b/src/granite/base.cr
@@ -35,6 +35,7 @@ require "./composite_primary_key"
 require "./secure_token"
 require "./signed_id"
 require "./token_for"
+require "./serialized_column"
 
 # Granite::Base is the base class for your model objects.
 abstract class Granite::Base
@@ -57,6 +58,7 @@ abstract class Granite::Base
 
   include ConnectionManagement
   include AttributeApi
+  include SerializedColumn
   
   # Make secure token macros available
   macro has_secure_token(name, length = 24, alphabet = :base58)

--- a/src/granite/serialized_column.cr
+++ b/src/granite/serialized_column.cr
@@ -1,0 +1,162 @@
+require "./serialized_object"
+require "./serializers/base"
+require "./serializers/json"
+require "./serializers/yaml"
+
+module Granite::SerializedColumn
+  # Base method that will be overridden by each serialized_column
+  def _mark_serialized_column_changed(attribute_name : String)
+    # This will be overridden by each serialized_column macro
+  end
+
+  macro serialized_column(name, klass, format = :json)
+    {% format_class = format.id.stringify.upcase %}
+    
+    # Define the underlying column with a different name
+    column _serialized_{{ name.id }} : String?
+    
+    # Store the serializer  
+    @_{{ name.id }}_serializer = Granite::Serializers::{{ format_class.id }}.new
+    
+    # Cache for the deserialized object
+    @[JSON::Field(ignore: true)]
+    @[YAML::Field(ignore: true)]
+    @_{{ name.id }}_cache : {{ klass }}?
+    
+    # Track if the serialized column has been modified
+    @[JSON::Field(ignore: true)]
+    @[YAML::Field(ignore: true)]
+    @_{{ name.id }}_modified = false
+    
+    # Getter to return deserialized object
+    def {{ name.id }} : {{ klass }}?
+      return @_{{ name.id }}_cache if @_{{ name.id }}_cache
+      
+      if raw_value = @_serialized_{{ name.id }}
+        obj = @_{{ name.id }}_serializer.deserialize(raw_value, {{ klass }})
+        
+        # Set up parent tracking if the object includes SerializedObject
+        if obj.responds_to?(:_set_parent)
+          obj._set_parent(self, {{ name.id.stringify }})
+        end
+        
+        @_{{ name.id }}_cache = obj
+        obj
+      else
+        nil
+      end
+    end
+    
+    # Custom setter
+    def {{ name.id }}=(value : {{ klass }}?)
+      @_{{ name.id }}_cache = value
+      
+      if value
+        # Set up parent tracking if the object includes SerializedObject
+        if value.responds_to?(:_set_parent)
+          value._set_parent(self, {{ name.id.stringify }})
+        end
+        
+        # Serialize immediately to store in the column
+        @_serialized_{{ name.id }} = @_{{ name.id }}_serializer.serialize(value)
+      else
+        @_serialized_{{ name.id }} = nil
+      end
+      
+      # Mark as changed for dirty tracking
+      ensure_dirty_tracking_initialized
+      
+      # Track the change in the standard dirty tracking system
+      if !new_record?
+        original = @original_attributes.not_nil!["_serialized_{{ name.id }}"]? || nil
+        current = @_serialized_{{ name.id }}.as(Granite::Base::DirtyValue?)
+        
+        if original != current
+          @changed_attributes.not_nil!["_serialized_{{ name.id }}"] = {
+            original || "".as(Granite::Base::DirtyValue), 
+            current || "".as(Granite::Base::DirtyValue)
+          }
+        end
+      end
+      
+      @_{{ name.id }}_modified = true
+      
+      value
+    end
+    
+    # Check if the serialized column has changed
+    def {{ name.id }}_changed?
+      return true if @_{{ name.id }}_modified
+      
+      # Check dirty tracking for the underlying column
+      if !new_record? && @changed_attributes
+        if @changed_attributes.not_nil!.has_key?("_serialized_{{ name.id }}")
+          return true
+        end
+      end
+      
+      # Also check if the cached object itself has changes
+      if cached = @_{{ name.id }}_cache
+        if cached.responds_to?(:changed?)
+          return cached.changed?
+        end
+      end
+      
+      false
+    end
+    
+    # Raw string setter (for direct column assignment)
+    def {{ name.id }}=(value : String)
+      @_{{ name.id }}_cache = nil
+      @_serialized_{{ name.id }} = value
+      
+      # Mark as changed for dirty tracking
+      ensure_dirty_tracking_initialized
+      
+      # Track the change in the standard dirty tracking system
+      if !new_record?
+        original = @original_attributes.not_nil!["_serialized_{{ name.id }}"]? || nil
+        current = @_serialized_{{ name.id }}.as(Granite::Base::DirtyValue?)
+        
+        if original != current
+          @changed_attributes.not_nil!["_serialized_{{ name.id }}"] = {
+            original || "".as(Granite::Base::DirtyValue), 
+            current || "".as(Granite::Base::DirtyValue)
+          }
+        end
+      end
+      
+      @_{{ name.id }}_modified = true
+    end
+    
+    # Ensure serialization before save
+    before_save :_serialize_{{ name.id }}
+    
+    private def _serialize_{{ name.id }}
+      if cached = @_{{ name.id }}_cache
+        @_serialized_{{ name.id }} = @_{{ name.id }}_serializer.serialize(cached)
+      end
+    end
+    
+    # Reset tracking after save
+    after_save :_reset_{{ name.id }}_tracking
+    
+    private def _reset_{{ name.id }}_tracking
+      @_{{ name.id }}_modified = false
+      if cached = @_{{ name.id }}_cache
+        if cached.responds_to?(:reset_changes!)
+          cached.reset_changes!
+        end
+      end
+    end
+    
+    # Define helper method for this specific column
+    def _mark_serialized_column_changed(attribute_name : String)
+      if attribute_name == {{ name.id.stringify }}
+        @_{{ name.id }}_modified = true
+      else
+        super
+      end
+    end
+  end
+end

--- a/src/granite/serialized_object.cr
+++ b/src/granite/serialized_object.cr
@@ -1,0 +1,71 @@
+module Granite::SerializedObject
+  @[JSON::Field(ignore: true)]
+  @[YAML::Field(ignore: true)]
+  @_changed : Bool = false
+
+  @[JSON::Field(ignore: true)]
+  @[YAML::Field(ignore: true)]
+  @_parent : Granite::Base?
+
+  @[JSON::Field(ignore: true)]
+  @[YAML::Field(ignore: true)]
+  @_attribute_name : String?
+
+  @[JSON::Field(ignore: true)]
+  @[YAML::Field(ignore: true)]
+  @_original_values = {} of String => Tuple(String, String)
+
+  def changed?
+    @_changed
+  end
+
+  def mark_as_changed!
+    @_changed = true
+    # Notify parent if set
+    if parent = @_parent
+      if attribute_name = @_attribute_name
+        # Use a method that exists on the parent
+        if parent.responds_to?(:_mark_serialized_column_changed)
+          parent._mark_serialized_column_changed(attribute_name)
+        end
+      end
+    end
+  end
+
+  def reset_changes!
+    @_changed = false
+    @_original_values.clear
+  end
+
+  def _set_parent(parent : Granite::Base, attribute_name : String)
+    @_parent = parent
+    @_attribute_name = attribute_name
+  end
+
+  # Track a change
+  def _track_change(property_name : String, old_value : String, new_value : String)
+    @_original_values[property_name] = {old_value, new_value}
+    mark_as_changed!
+  end
+
+  def changes
+    @_original_values.dup
+  end
+
+  # Helper macro to add change tracking to properties
+  macro track_changes_for(*properties)
+    {% for prop in properties %}
+      {% prop_name = prop.id.stringify %}
+      
+      # Getter is already defined by property declaration
+      # Just define the custom setter
+      def {{ prop.id }}=(value)
+        old_val = @{{ prop.id }}
+        if old_val != value
+          _track_change({{ prop_name }}, old_val.to_s, value.to_s)
+        end
+        @{{ prop.id }} = value
+      end
+    {% end %}
+  end
+end

--- a/src/granite/serializers/base.cr
+++ b/src/granite/serializers/base.cr
@@ -1,0 +1,6 @@
+module Granite::Serializers
+  abstract class Base
+    abstract def serialize(object) : String
+    abstract def deserialize(string : String, klass) : Object
+  end
+end

--- a/src/granite/serializers/json.cr
+++ b/src/granite/serializers/json.cr
@@ -1,0 +1,19 @@
+require "json"
+require "./base"
+
+module Granite::Serializers
+  class JSON < Base
+    def serialize(object) : String
+      object.to_json
+    end
+
+    def deserialize(string : String, klass) : Object
+      klass.from_json(string)
+    end
+  end
+
+  # JSONB uses the same serialization as JSON
+  # The difference is handled at the database adapter level
+  class JSONB < JSON
+  end
+end

--- a/src/granite/serializers/yaml.cr
+++ b/src/granite/serializers/yaml.cr
@@ -1,0 +1,14 @@
+require "yaml"
+require "./base"
+
+module Granite::Serializers
+  class YAML < Base
+    def serialize(object) : String
+      object.to_yaml
+    end
+
+    def deserialize(string : String, klass) : Object
+      klass.from_yaml(string)
+    end
+  end
+end


### PR DESCRIPTION
## Summary

This PR implements a `serialized_column` macro for storing complex objects in JSON, JSONB, and YAML database columns, addressing issue #20.

## Implementation Approach

After discussing the requirements, we decided **against** an "accessor-like" API that would flatten object properties onto the parent model. Instead, we implemented a `serialized_column` macro that:

- Keeps objects as their own instances (not flattened)
- Integrates with Grant's dirty tracking system
- Supports automatic serialization/deserialization
- Works with JSON, JSONB, and YAML column types

## Why This Approach?

1. **Maintains Object Encapsulation**: Settings/preferences remain as cohesive objects rather than scattered properties
2. **Type Safety**: Full Crystal type checking for nested objects
3. **Dirty Tracking**: Changes to nested objects are tracked and propagate to the parent model
4. **Flexibility**: Easy to add new serialization formats in the future
5. **Clean API**: Simple macro syntax that's familiar to Rails developers

## Usage Example

```crystal
class User < Granite::Base
  # Define a serialized column
  serialized_column :settings, UserSettings, format: :json
end

class UserSettings
  include JSON::Serializable
  include Granite::SerializedObject
  
  property theme : String = "light"
  property notifications : Bool = true
  
  track_changes_for theme, notifications
end

# Usage
user = User.new
user.settings = UserSettings.new(theme: "dark")
user.settings.theme # => "dark"
user.settings_changed? # => true
user.save # Automatically serializes to JSON
```

## Features

- ✅ Automatic serialization/deserialization
- ✅ Support for JSON, JSONB, and YAML formats
- ✅ Dirty tracking integration for nested objects
- ✅ Lazy deserialization with caching
- ✅ Type-safe Crystal objects
- ✅ Comprehensive test coverage
- ✅ Full documentation

## Database Storage

The serialized data is stored in a single column prefixed with `_serialized_` to avoid naming conflicts:
- `serialized_column :settings` → creates `_serialized_settings` column
- Column type depends on format and database adapter

## Test Plan

- [x] All tests passing locally
- [x] JSON serialization/deserialization
- [x] JSONB support (PostgreSQL)
- [x] YAML serialization
- [x] Dirty tracking propagation
- [x] Caching behavior
- [x] Edge cases (nil values, etc.)

Closes #20

🤖 Generated with [Claude Code](https://claude.ai/code)